### PR TITLE
Remove spaces from rcon-command names

### DIFF
--- a/ExtendedRcon/ExtendedRcon/ExtendedRcon.cpp
+++ b/ExtendedRcon/ExtendedRcon/ExtendedRcon.cpp
@@ -749,8 +749,8 @@ void Init()
 	Ark::AddRconCommand(L"GiveItem", &GiveItem);
 	Ark::AddRconCommand(L"AddExperience", &AddExperience);
 	Ark::AddRconCommand(L"SetPlayerPos", &SetPlayerPos);
-	Ark::AddRconCommand(L"GetPlayerPos ", &GetPlayerPos);
-	Ark::AddRconCommand(L"KillPlayer ", &KillPlayer);
+	Ark::AddRconCommand(L"GetPlayerPos", &GetPlayerPos);
+	Ark::AddRconCommand(L"KillPlayer", &KillPlayer);
 	Ark::AddRconCommand(L"TeleportToPlayer", &TeleportToPlayer);
 	Ark::AddRconCommand(L"ListPlayerDinos", &ListPlayerDinos);
 	Ark::AddRconCommand(L"GetTribeIdOfPlayer", &GetTribeIdOfPlayer);


### PR DESCRIPTION
KillPlayer and GetPlayerPos commands are not working after updating the command-check in the ArkApi to use FString::Compare. This is due to extra spaces in the command name registration.

This tiny fix makes the two commands work properly again.