### PR TITLE
Permissions| Changing behaviour of AddPlayerToGroup

### DIFF
--- a/Permissions/Permissions/Private/Database/MysqlDB.h
+++ b/Permissions/Permissions/Private/Database/MysqlDB.h
@@ -212,8 +212,11 @@ public:
 
 	std::optional<std::string> AddPlayerToGroup(uint64 steam_id, const FString& group) override
 	{
-		if (!IsPlayerExists(steam_id) || !IsGroupExists(group))
-			return "Player or group does not exist";
+		if (!IsPlayerExists(steam_id))
+			AddPlayer(steam_id);
+
+		if (!IsGroupExists(group))
+			return  "Group does not exist";
 
 		if (Permissions::IsPlayerInGroup(steam_id, group))
 			return "Player was already added";

--- a/Permissions/Permissions/Private/Database/SqlLiteDB.h
+++ b/Permissions/Permissions/Private/Database/SqlLiteDB.h
@@ -198,11 +198,11 @@ public:
 
 	std::optional<std::string> AddPlayerToGroup(uint64 steam_id, const FString& group) override
 	{
-		if (!IsPlayerExists(steam_id) || !IsGroupExists(group))
-			return "Player or group does not exist";
+		if (!IsPlayerExists(steam_id))
+			AddPlayer(steam_id);
 
-		if (Permissions::IsPlayerInGroup(steam_id, group))
-			return "Player was already added";
+		if (!IsGroupExists(group))
+			return  "Group does not exist";
 
 		try
 		{

--- a/Permissions/Permissions/Private/Database/SqlLiteDB.h
+++ b/Permissions/Permissions/Private/Database/SqlLiteDB.h
@@ -204,6 +204,9 @@ public:
 		if (!IsGroupExists(group))
 			return  "Group does not exist";
 
+		if (Permissions::IsPlayerInGroup(steam_id, group))
+			return "Player was already added";
+
 		try
 		{
 			SQLite::Statement query(db_, "UPDATE Players SET Groups = Groups || ? || ',' WHERE SteamId = ?;");


### PR DESCRIPTION
This is thered87 :)

I needed to change the handling of AddPlayerToGroup a little, to ensure, the user exists when I assign a Group to him (Since AddPlayer ist not public).

This is necessary, because there are earlier entry points than HandleNewPlayer and it's cleaner as making AddPlayer public.