### PR TITLE
Fixed GetAllGroups accessing the wrong cached value.

### DIFF
--- a/Permissions/Permissions/Private/Database/MysqlDB.h
+++ b/Permissions/Permissions/Private/Database/MysqlDB.h
@@ -159,7 +159,7 @@ public:
 
 		for (auto& group : permissionGroups)
 		{
-			all_groups.Add(group.second.c_str());
+			all_groups.Add(group.first.c_str());
 		}
 
 		return all_groups;

--- a/Permissions/Permissions/Private/Database/SqlLiteDB.h
+++ b/Permissions/Permissions/Private/Database/SqlLiteDB.h
@@ -139,7 +139,7 @@ public:
 
 		for (auto& group : permissionGroups)
 		{
-			all_groups.Add(group.second.c_str());
+			all_groups.Add(group.first.c_str());
 		}
 
 		return all_groups;


### PR DESCRIPTION
This will fix the "permissions.listgroups" command showing blank group names.