### PR TITLE
Set cache objects to protected to prevent access outside of the datab…

### DIFF
--- a/Permissions/Permissions/Private/Database/IDatabase.h
+++ b/Permissions/Permissions/Private/Database/IDatabase.h
@@ -9,19 +9,23 @@
 
 class IDatabase
 {
-public:
+protected:
 	std::unordered_map<std::string, std::string> permissionGroups;
 	std::unordered_map<uint64, CachedPermission> permissionPlayers;
 	std::unordered_map<int, CachedPermission> permissionTribes;
 	std::mutex playersMutex, groupsMutex, tribesMutex;
 
+public:
 	virtual ~IDatabase() = default;
 
 	virtual bool IsFieldExists(std::string tableName, std::string fieldName) = 0;
-	virtual bool AddPlayer(uint64 steam_id) = 0;
+
 	virtual bool IsPlayerExists(uint64 steam_id) = 0;
+	virtual bool AddPlayer(uint64 steam_id) = 0;
+
 	virtual bool IsGroupExists(const FString& group) = 0;
 	virtual TArray<FString> GetPlayerGroups(uint64 steam_id) = 0;
+	virtual CachedPermission HydratePlayerGroups(uint64 steam_id) = 0;
 	virtual TArray<FString> GetGroupPermissions(const FString& group) = 0;
 	virtual TArray<FString> GetAllGroups() = 0;
 	virtual TArray<uint64> GetGroupMembers(const FString& group) = 0;
@@ -31,17 +35,19 @@ public:
 	virtual std::optional<std::string> RemoveGroup(const FString& group) = 0;
 	virtual std::optional<std::string> GroupGrantPermission(const FString& group, const FString& permission) = 0;
 	virtual std::optional<std::string> GroupRevokePermission(const FString& group, const FString& permission) = 0;
-
 	virtual std::optional<std::string> AddPlayerToTimedGroup(uint64 steam_id, const FString& group, int secs, int delaySecs) = 0;
 	virtual std::optional<std::string> RemovePlayerFromTimedGroup(uint64 steam_id, const FString& group) = 0;
+	virtual void UpdatePlayerGroupCallbacks(uint64 steamId, TArray<FString> groups) = 0;
 
-	virtual bool AddTribe(int tribeId) = 0;
 	virtual bool IsTribeExists(int tribeId) = 0;
+	virtual bool AddTribe(int tribeId) = 0;
 	virtual TArray<FString> GetTribeGroups(int tribeId) = 0;
+	virtual CachedPermission HydrateTribeGroups(int tribeId) = 0;
 	virtual std::optional<std::string> AddTribeToGroup(int tribeId, const FString& group) = 0;
 	virtual std::optional<std::string> RemoveTribeFromGroup(int tribeId, const FString& group) = 0;
 	virtual std::optional<std::string> AddTribeToTimedGroup(int tribeId, const FString& group, int secs, int delaySecs) = 0;
 	virtual std::optional<std::string> RemoveTribeFromTimedGroup(int tribeId, const FString& group) = 0;
+	virtual void UpdateTribeGroupCallbacks(int tribeId, TArray<FString> groups) = 0;
 
 	virtual void Init() = 0;
 	virtual std::unordered_map<std::string, std::string> InitGroups() = 0;

--- a/Permissions/Permissions/Private/Main.cpp
+++ b/Permissions/Permissions/Private/Main.cpp
@@ -651,9 +651,10 @@ namespace Permissions
 	}
 
 	FString GetTribeGroupsStr(FString tribeDefaults, int tribe_id, bool forChat) {
-		if (database->permissionTribes.count(tribe_id) == 0)
+		if (!database->IsTribeExists(tribe_id))
 			return "";
-		CachedPermission permissions = database->permissionTribes[tribe_id];
+
+		CachedPermission permissions = database->HydrateTribeGroups(tribe_id);
 
 		FString groups_str = tribeDefaults;
 		for (int32 Index = 0; Index != permissions.Groups.Num(); ++Index) {
@@ -689,9 +690,10 @@ namespace Permissions
 	}
 
 	FString GetPlayerGroupsStr(uint64 steam_id, bool forChat) {
-		if (database->permissionPlayers.count(steam_id) == 0)
+		if (!database->IsPlayerExists(steam_id))
 			return "";
-		CachedPermission permissions = database->permissionPlayers[steam_id];
+
+		CachedPermission permissions = database->HydratePlayerGroups(steam_id);
 
 		FString groups_str;
 		for (const FString& current_group : permissions.Groups)


### PR DESCRIPTION
Set cache objects to protected to prevent access outside of the database layer.

Fixed Timed permission using the cache objects directly.
Added new methods to pull a cached object and update callback groups.
Fixed typo in callbacks using tribeId when it should have been steamId