### PR TITLE
Prevent timed permissions from incorrectly becoming permanent

### DIFF
--- a/Permissions/Permissions/Private/Database/IDatabase.h
+++ b/Permissions/Permissions/Private/Database/IDatabase.h
@@ -24,8 +24,7 @@ public:
 	virtual bool AddPlayer(uint64 steam_id) = 0;
 
 	virtual bool IsGroupExists(const FString& group) = 0;
-	virtual TArray<FString> GetPlayerGroups(uint64 steam_id, bool includeTimed) = 0;
-	virtual TArray<FString> GetPlayerGroups(uint64 steam_id) = 0;
+	virtual TArray<FString> GetPlayerGroups(uint64 steam_id, bool includeTimed = true) = 0;
 	virtual CachedPermission HydratePlayerGroups(uint64 steam_id) = 0;
 	virtual TArray<FString> GetGroupPermissions(const FString& group) = 0;
 	virtual TArray<FString> GetAllGroups() = 0;
@@ -42,8 +41,7 @@ public:
 
 	virtual bool IsTribeExists(int tribeId) = 0;
 	virtual bool AddTribe(int tribeId) = 0;
-	virtual TArray<FString> GetTribeGroups(int tribeId, bool includeTimed) = 0;
-	virtual TArray<FString> GetTribeGroups(int tribeId) = 0;
+	virtual TArray<FString> GetTribeGroups(int tribeId, bool includeTimed = true) = 0;
 	virtual CachedPermission HydrateTribeGroups(int tribeId) = 0;
 	virtual std::optional<std::string> AddTribeToGroup(int tribeId, const FString& group) = 0;
 	virtual std::optional<std::string> RemoveTribeFromGroup(int tribeId, const FString& group) = 0;

--- a/Permissions/Permissions/Private/Database/IDatabase.h
+++ b/Permissions/Permissions/Private/Database/IDatabase.h
@@ -24,6 +24,7 @@ public:
 	virtual bool AddPlayer(uint64 steam_id) = 0;
 
 	virtual bool IsGroupExists(const FString& group) = 0;
+	virtual TArray<FString> GetPlayerGroups(uint64 steam_id, bool includeTimed) = 0;
 	virtual TArray<FString> GetPlayerGroups(uint64 steam_id) = 0;
 	virtual CachedPermission HydratePlayerGroups(uint64 steam_id) = 0;
 	virtual TArray<FString> GetGroupPermissions(const FString& group) = 0;
@@ -41,6 +42,7 @@ public:
 
 	virtual bool IsTribeExists(int tribeId) = 0;
 	virtual bool AddTribe(int tribeId) = 0;
+	virtual TArray<FString> GetTribeGroups(int tribeId, bool includeTimed) = 0;
 	virtual TArray<FString> GetTribeGroups(int tribeId) = 0;
 	virtual CachedPermission HydrateTribeGroups(int tribeId) = 0;
 	virtual std::optional<std::string> AddTribeToGroup(int tribeId, const FString& group) = 0;

--- a/Permissions/Permissions/Private/Database/MysqlDB.h
+++ b/Permissions/Permissions/Private/Database/MysqlDB.h
@@ -217,7 +217,10 @@ public:
 
 		try
 		{
-			auto groups = GetPlayerGroups(steam_id);
+			playersMutex.lock();
+			TArray<FString> groups = permissionPlayers[steam_id].Groups;
+			playersMutex.unlock();
+
 			groups.AddUnique(group);
 
 			FString query_groups("");
@@ -255,7 +258,9 @@ public:
 		if (!Permissions::IsPlayerInGroup(steam_id, group))
 			return "Player is not in group";
 
-		TArray<FString> groups = GetPlayerGroups(steam_id);
+		playersMutex.lock();
+		TArray<FString> groups = permissionPlayers[steam_id].Groups;
+		playersMutex.unlock();
 
 		FString new_groups;
 
@@ -609,7 +614,10 @@ public:
 
 		try
 		{
-			auto groups = GetTribeGroups(tribeId);
+			tribesMutex.lock();
+			TArray<FString> groups = permissionTribes[tribeId].Groups;
+			tribesMutex.unlock();
+
 			groups.AddUnique(group);
 
 			FString query_groups("");
@@ -647,7 +655,9 @@ public:
 		if (!Permissions::IsTribeInGroup(tribeId, group))
 			return "Tribe is not in group";
 
-		TArray<FString> groups = GetTribeGroups(tribeId);
+		tribesMutex.lock();
+		TArray<FString> groups = permissionTribes[tribeId].Groups;
+		tribesMutex.unlock();
 
 		FString new_groups;
 

--- a/Permissions/Permissions/Private/Database/MysqlDB.h
+++ b/Permissions/Permissions/Private/Database/MysqlDB.h
@@ -217,10 +217,7 @@ public:
 
 		try
 		{
-			playersMutex.lock();
-			TArray<FString> groups = permissionPlayers[steam_id].Groups;
-			playersMutex.unlock();
-
+			auto groups = GetPlayerGroups(steam_id);
 			groups.AddUnique(group);
 
 			FString query_groups("");
@@ -258,9 +255,7 @@ public:
 		if (!Permissions::IsPlayerInGroup(steam_id, group))
 			return "Player is not in group";
 
-		playersMutex.lock();
-		TArray<FString> groups = permissionPlayers[steam_id].Groups;
-		playersMutex.unlock();
+		TArray<FString> groups = GetPlayerGroups(steam_id);
 
 		FString new_groups;
 
@@ -614,10 +609,7 @@ public:
 
 		try
 		{
-			tribesMutex.lock();
-			TArray<FString> groups = permissionTribes[tribeId].Groups;
-			tribesMutex.unlock();
-
+			auto groups = GetTribeGroups(tribeId);
 			groups.AddUnique(group);
 
 			FString query_groups("");
@@ -655,9 +647,7 @@ public:
 		if (!Permissions::IsTribeInGroup(tribeId, group))
 			return "Tribe is not in group";
 
-		tribesMutex.lock();
-		TArray<FString> groups = permissionTribes[tribeId].Groups;
-		tribesMutex.unlock();
+		TArray<FString> groups = GetTribeGroups(tribeId);
 
 		FString new_groups;
 

--- a/Permissions/Permissions/Private/Database/MysqlDB.h
+++ b/Permissions/Permissions/Private/Database/MysqlDB.h
@@ -132,7 +132,7 @@ public:
 		return true;
 	}
 
-	TArray<FString> GetPlayerGroups(uint64 steam_id, bool includeTimed) override
+	TArray<FString> GetPlayerGroups(uint64 steam_id, bool includeTimed = true) override
 	{
 		TArray<FString> groups;
 
@@ -151,11 +151,6 @@ public:
 		}
 
 		return groups;
-	}
-
-	TArray<FString> GetPlayerGroups(uint64 steam_id) override
-	{
-		return GetPlayerGroups(steam_id, true);
 	}
 
 	CachedPermission HydratePlayerGroups(uint64 steam_id) override
@@ -588,7 +583,7 @@ public:
 		return false;
 	}
 
-	TArray<FString> GetTribeGroups(int tribeId, bool includeTimed) override
+	TArray<FString> GetTribeGroups(int tribeId, bool includeTimed = true) override
 	{
 		TArray<FString> groups;
 
@@ -607,11 +602,6 @@ public:
 		}
 
 		return groups;
-	}
-
-	TArray<FString> GetTribeGroups(int tribeId) override
-	{
-		return GetTribeGroups(tribeId, true);
 	}
 
 	CachedPermission HydrateTribeGroups(int tribeId) override

--- a/Permissions/Permissions/Private/Database/MysqlDB.h
+++ b/Permissions/Permissions/Private/Database/MysqlDB.h
@@ -132,18 +132,30 @@ public:
 		return true;
 	}
 
-	TArray<FString> GetPlayerGroups(uint64 steam_id) override
+	TArray<FString> GetPlayerGroups(uint64 steam_id, bool includeTimed) override
 	{
 		TArray<FString> groups;
-		auto nowSecs = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count();
 
 		if (IsPlayerExists(steam_id))
 		{
 			std::lock_guard<std::mutex> lg(playersMutex);
-			groups = permissionPlayers[steam_id].getGroups(nowSecs);
+			if (includeTimed)
+			{
+				auto nowSecs = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+				groups = permissionPlayers[steam_id].getGroups(nowSecs);
+			}
+			else
+			{
+				groups = permissionPlayers[steam_id].Groups;
+			}
 		}
 
 		return groups;
+	}
+
+	TArray<FString> GetPlayerGroups(uint64 steam_id) override
+	{
+		return GetPlayerGroups(steam_id, true);
 	}
 
 	CachedPermission HydratePlayerGroups(uint64 steam_id) override
@@ -217,7 +229,7 @@ public:
 
 		try
 		{
-			auto groups = GetPlayerGroups(steam_id);
+			auto groups = GetPlayerGroups(steam_id, false);
 			groups.AddUnique(group);
 
 			FString query_groups("");
@@ -255,7 +267,7 @@ public:
 		if (!Permissions::IsPlayerInGroup(steam_id, group))
 			return "Player is not in group";
 
-		TArray<FString> groups = GetPlayerGroups(steam_id);
+		TArray<FString> groups = GetPlayerGroups(steam_id, false);
 
 		FString new_groups;
 
@@ -576,18 +588,30 @@ public:
 		return false;
 	}
 
-	TArray<FString> GetTribeGroups(int tribeId) override
+	TArray<FString> GetTribeGroups(int tribeId, bool includeTimed) override
 	{
 		TArray<FString> groups;
-		auto nowSecs = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count();
 
 		if (IsTribeExists(tribeId))
 		{
 			std::lock_guard<std::mutex> lg(tribesMutex);
-			groups = permissionTribes[tribeId].getGroups(nowSecs);
+			if (includeTimed)
+			{
+				auto nowSecs = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+				groups = permissionTribes[tribeId].getGroups(nowSecs);
+			}
+			else
+			{
+				groups = permissionTribes[tribeId].Groups;
+			}
 		}
 
 		return groups;
+	}
+
+	TArray<FString> GetTribeGroups(int tribeId) override
+	{
+		return GetTribeGroups(tribeId, true);
 	}
 
 	CachedPermission HydrateTribeGroups(int tribeId) override
@@ -609,7 +633,7 @@ public:
 
 		try
 		{
-			auto groups = GetTribeGroups(tribeId);
+			auto groups = GetTribeGroups(tribeId, false);
 			groups.AddUnique(group);
 
 			FString query_groups("");
@@ -647,7 +671,7 @@ public:
 		if (!Permissions::IsTribeInGroup(tribeId, group))
 			return "Tribe is not in group";
 
-		TArray<FString> groups = GetTribeGroups(tribeId);
+		TArray<FString> groups = GetTribeGroups(tribeId, false);
 
 		FString new_groups;
 

--- a/Permissions/Permissions/Private/Database/SqlLiteDB.h
+++ b/Permissions/Permissions/Private/Database/SqlLiteDB.h
@@ -197,10 +197,7 @@ public:
 
 		try
 		{
-			playersMutex.lock();
-			TArray<FString> groups = permissionPlayers[steam_id].Groups;
-			playersMutex.unlock();
-
+			auto groups = GetPlayerGroups(steam_id);
 			groups.AddUnique(group);
 
 			FString query_groups("");
@@ -233,9 +230,7 @@ public:
 		if (!Permissions::IsPlayerInGroup(steam_id, group))
 			return "Player is not in group";
 
-		playersMutex.lock();
-		TArray<FString> groups = permissionPlayers[steam_id].Groups;
-		playersMutex.unlock();
+		TArray<FString> groups = GetPlayerGroups(steam_id);
 
 		FString new_groups;
 
@@ -557,10 +552,7 @@ public:
 
 		try
 		{
-			tribesMutex.lock();
-			TArray<FString> groups = permissionTribes[tribeId].Groups;
-			tribesMutex.unlock();
-
+			auto groups = GetTribeGroups(tribeId);
 			groups.AddUnique(group);
 
 			FString query_groups("");
@@ -593,9 +585,7 @@ public:
 		if (!Permissions::IsTribeInGroup(tribeId, group))
 			return "Tribe is not in group";
 
-		tribesMutex.lock();
-		TArray<FString> groups = permissionTribes[tribeId].Groups;
-		tribesMutex.unlock();
+		TArray<FString> groups = GetTribeGroups(tribeId);
 
 		FString new_groups;
 

--- a/Permissions/Permissions/Private/Database/SqlLiteDB.h
+++ b/Permissions/Permissions/Private/Database/SqlLiteDB.h
@@ -197,7 +197,10 @@ public:
 
 		try
 		{
-			auto groups = GetPlayerGroups(steam_id);
+			playersMutex.lock();
+			TArray<FString> groups = permissionPlayers[steam_id].Groups;
+			playersMutex.unlock();
+
 			groups.AddUnique(group);
 
 			FString query_groups("");
@@ -230,7 +233,9 @@ public:
 		if (!Permissions::IsPlayerInGroup(steam_id, group))
 			return "Player is not in group";
 
-		TArray<FString> groups = GetPlayerGroups(steam_id);
+		playersMutex.lock();
+		TArray<FString> groups = permissionPlayers[steam_id].Groups;
+		playersMutex.unlock();
 
 		FString new_groups;
 
@@ -552,7 +557,10 @@ public:
 
 		try
 		{
-			auto groups = GetTribeGroups(tribeId);
+			tribesMutex.lock();
+			TArray<FString> groups = permissionTribes[tribeId].Groups;
+			tribesMutex.unlock();
+
 			groups.AddUnique(group);
 
 			FString query_groups("");
@@ -585,7 +593,9 @@ public:
 		if (!Permissions::IsTribeInGroup(tribeId, group))
 			return "Tribe is not in group";
 
-		TArray<FString> groups = GetTribeGroups(tribeId);
+		tribesMutex.lock();
+		TArray<FString> groups = permissionTribes[tribeId].Groups;
+		tribesMutex.unlock();
 
 		FString new_groups;
 

--- a/Permissions/Permissions/Private/Database/SqlLiteDB.h
+++ b/Permissions/Permissions/Private/Database/SqlLiteDB.h
@@ -121,7 +121,7 @@ public:
 		return found;
 	}
 
-	TArray<FString> GetPlayerGroups(uint64 steam_id, bool includeTimed) override
+	TArray<FString> GetPlayerGroups(uint64 steam_id, bool includeTimed = true) override
 	{
 		TArray<FString> groups;
 
@@ -140,11 +140,6 @@ public:
 		}
 
 		return groups;
-	}
-
-	TArray<FString> GetPlayerGroups(uint64 steam_id) override
-	{
-		return GetPlayerGroups(steam_id, true);
 	}
 
 	CachedPermission HydratePlayerGroups(uint64 steam_id) override
@@ -532,7 +527,7 @@ public:
 		return false;
 	}
 
-	TArray<FString> GetTribeGroups(int tribeId, bool includeTimed) override
+	TArray<FString> GetTribeGroups(int tribeId, bool includeTimed = true) override
 	{
 		TArray<FString> groups;
 
@@ -551,11 +546,6 @@ public:
 		}
 
 		return groups;
-	}
-
-	TArray<FString> GetTribeGroups(int tribeId) override
-	{
-		return GetTribeGroups(tribeId, true);
 	}
 
 	CachedPermission HydrateTribeGroups(int tribeId) override

--- a/Permissions/Permissions/Private/Database/SqlLiteDB.h
+++ b/Permissions/Permissions/Private/Database/SqlLiteDB.h
@@ -121,17 +121,30 @@ public:
 		return found;
 	}
 
-	TArray<FString> GetPlayerGroups(uint64 steam_id) override
+	TArray<FString> GetPlayerGroups(uint64 steam_id, bool includeTimed) override
 	{
 		TArray<FString> groups;
-		auto nowSecs = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count();
 
 		if (IsPlayerExists(steam_id))
 		{
 			std::lock_guard<std::mutex> lg(playersMutex);
-			groups = permissionPlayers[steam_id].getGroups(nowSecs);
+			if (includeTimed)
+			{
+				auto nowSecs = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+				groups = permissionPlayers[steam_id].getGroups(nowSecs);
+			}
+			else
+			{
+				groups = permissionPlayers[steam_id].Groups;
+			}
 		}
+
 		return groups;
+	}
+
+	TArray<FString> GetPlayerGroups(uint64 steam_id) override
+	{
+		return GetPlayerGroups(steam_id, true);
 	}
 
 	CachedPermission HydratePlayerGroups(uint64 steam_id) override
@@ -197,7 +210,7 @@ public:
 
 		try
 		{
-			auto groups = GetPlayerGroups(steam_id);
+			auto groups = GetPlayerGroups(steam_id, false);
 			groups.AddUnique(group);
 
 			FString query_groups("");
@@ -230,7 +243,7 @@ public:
 		if (!Permissions::IsPlayerInGroup(steam_id, group))
 			return "Player is not in group";
 
-		TArray<FString> groups = GetPlayerGroups(steam_id);
+		TArray<FString> groups = GetPlayerGroups(steam_id, false);
 
 		FString new_groups;
 
@@ -519,18 +532,30 @@ public:
 		return false;
 	}
 
-	TArray<FString> GetTribeGroups(int tribeId) override
+	TArray<FString> GetTribeGroups(int tribeId, bool includeTimed) override
 	{
 		TArray<FString> groups;
-		auto nowSecs = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count();
 
 		if (IsTribeExists(tribeId))
 		{
 			std::lock_guard<std::mutex> lg(tribesMutex);
-			groups = permissionTribes[tribeId].getGroups(nowSecs);
+			if (includeTimed)
+			{
+				auto nowSecs = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+				groups = permissionTribes[tribeId].getGroups(nowSecs);
+			}
+			else
+			{
+				groups = permissionTribes[tribeId].Groups;
+			}
 		}
 
 		return groups;
+	}
+
+	TArray<FString> GetTribeGroups(int tribeId) override
+	{
+		return GetTribeGroups(tribeId, true);
 	}
 
 	CachedPermission HydrateTribeGroups(int tribeId) override
@@ -552,7 +577,7 @@ public:
 
 		try
 		{
-			auto groups = GetTribeGroups(tribeId);
+			auto groups = GetTribeGroups(tribeId, false);
 			groups.AddUnique(group);
 
 			FString query_groups("");
@@ -585,7 +610,7 @@ public:
 		if (!Permissions::IsTribeInGroup(tribeId, group))
 			return "Tribe is not in group";
 
-		TArray<FString> groups = GetTribeGroups(tribeId);
+		TArray<FString> groups = GetTribeGroups(tribeId, false);
 
 		FString new_groups;
 


### PR DESCRIPTION
Calls to `AddPlayerToGroup()`, `RemovePlayerFromGroup()`, `AddTribeToGroup()`, and `RemoveTribeFromGroup()` currently cause active timed groups to incorrectly get added as permanent groups. This is because these functions operate on the result of `GetPlayerGroups()`, which includes current timed groups. When these functions write the new set of permanent groups to the database, timed groups are included in the string. The local cache is initially updated properly, but is overwritten upon syncing.

This change solves the problem by skipping the call to `GetPlayerGroups()` (which is working as intended for other uses) and getting a working set of permanent groups directly from the cache.